### PR TITLE
Fix query pipeline for multiple transforms

### DIFF
--- a/bowler/tests/smoke-target.py
+++ b/bowler/tests/smoke-target.py
@@ -2,3 +2,6 @@
 
 # todo: i18n
 print("Hello world!")
+
+def foo():
+    pass

--- a/bowler/tests/smoke.py
+++ b/bowler/tests/smoke.py
@@ -34,16 +34,20 @@ class SmokeTest(TestCase):
 
             self.assertIn("""-print("Hello world!")""", hunk)
             self.assertIn("""+print(tr("Hello world!"))""", hunk)
+            self.assertIn("""-def foo():""", hunk)
+            self.assertIn("""+def foo(bar="something"):""", hunk)
 
         (
             Query(str(target))
             .select(
                 """
                 power< "print" trailer< "(" args=any* ")" > >
-            """
+                """
             )
             .filter(takes_string_literal)
             .modify(wrap_string)
+            .select_function("foo")
+            .add_argument("bar", '"something"')
             .process(verify_hunk)
             .silent()
         )

--- a/bowler/tool.py
+++ b/bowler/tool.py
@@ -98,8 +98,9 @@ class BowlerTool(RefactoringTool):
             self.hunk_processor = lambda f, h: True
 
     def get_fixers(self) -> Tuple[Fixers, Fixers]:
-        pre: Fixers = []
-        post: Fixers = [f(self.options, self.fixer_log) for f in self.fixers]
+        fixers = [f(self.options, self.fixer_log) for f in self.fixers]
+        pre: Fixers = [f for f in fixers if f.order == "pre"]
+        post: Fixers = [f for f in fixers if f.order == "post"]
         return pre, post
 
     def processed_file(


### PR DESCRIPTION
Fixes #1 by moving the fixer generation from the `compile()` method to
a separate `create_fixer()` method, so that the bound transform is
preserved correctly.