### PR TITLE
[docs/api-query] select_name -> select_function

### DIFF
--- a/docs/api-query.md
+++ b/docs/api-query.md
@@ -13,7 +13,7 @@ Example usage of the fluent API:
 ```python
 (
     Query()
-    .select_name("foo")
+    .select_function("foo")
     .rename("bar")
     .diff()
 )
@@ -24,7 +24,7 @@ build, and execute an equivalent query without the fluent API:
 
 ```python
 query = Query()
-query.select_name("foo")
+query.select_function("foo")
 query.rename("bar")
 query.diff()
 ```


### PR DESCRIPTION
This is to solve https://github.com/facebookincubator/Bowler/issues/4

I *assume* there was an API change and the documentation wasn't updated. 
I also assume that the intention was to change a function name.

Also, when running `make lint` I got changes for `bowler/tests/smoke-target.py`, which I think should be fixed in another PR.
