### PR TITLE
Fix #6: Match await keyword in select_function/method

### DIFF
--- a/bowler/query.py
+++ b/bowler/query.py
@@ -142,6 +142,7 @@ class Query:
              [')'] >
         |
             module_name=power<
+                [TOKEN]
                 {power_name}
                 module_access=trailer< any* >*
             >
@@ -318,6 +319,7 @@ class Query:
             >
         |
             function_call=power<
+                [TOKEN]
                 function_name='{name}'
                 function_parameters=trailer< '(' function_arguments=any* ')' >
                 remainder=any*


### PR DESCRIPTION
The selectors for function/method calls did not account for the
'await' keyword in the grammar for power elements, preventing Bowler
from correctly matching and modifying awaited coroutines.  This
adds the generic, optional `TOKEN` element to the selectors to match
those keywords when used.