### PR TITLE
Let selectors match methods/functions with multiple decorators

### DIFF
--- a/bowler/query.py
+++ b/bowler/query.py
@@ -265,7 +265,7 @@ class Query:
         """
         (
             decorated=decorated<
-                decorator=decorator< any* >
+                decorators=decorators
                 function_def=funcdef<
                     'def' function_name='{name}'
                     function_parameters=parameters< '('
@@ -303,7 +303,7 @@ class Query:
         """
         (
             decorated=decorated<
-                decorator=decorator< any* >
+                decorators=decorators
                 function_def=funcdef<
                     'def' function_name='{name}'
                     function_parameters=parameters< '(' function_arguments=any* ')' >

--- a/docs/api-selectors.md
+++ b/docs/api-selectors.md
@@ -169,7 +169,7 @@ query.select_method(name: str)
 
 Capture | Description | Example | Match
 ---|---|---|---
-decorator | Method decorator | `@classmethod` | `@classmethod`
+decorators | Method decorators | `@classmethod` | `@classmethod`
 function_arguments | Method arguments | `def foo(self):` | `[self]`
 function_call | Method invocation | `foo.bar()` | `foo`
 function_def | Method definition | `def foo(self):` | `def`
@@ -185,7 +185,7 @@ query.select_class(name: str)
 
 Capture | Description | Example | Match
 ---|---|---|---
-decorator | Function decorator | `@wraps` | `@wraps`
+decorators | Function decorators | `@wraps` | `@wraps`
 function_arguments | Function arguments | `def foo(a, b):` | `[a, b]`
 function_call | Function invocation | `foo()` | `foo`
 function_def | Function definition | `def foo(self):` | `def`


### PR DESCRIPTION
Change the `.select_method()` and `.select_function()` selectors to
allow selection of methods/functions with multiple decorators.

Before this change only the `funcdef` node will be selected, but now the entire `decorated` node is selected.

```foo.py
@test_decorator
@some_other_decorator
def foo():
    pass
```