### PR TITLE
Accept files with no trailing newline + minor revisions

### DIFF
--- a/bowler/main.py
+++ b/bowler/main.py
@@ -20,7 +20,7 @@ from .types import START, SYMBOL, TOKEN
 def main(ctx: click.Context, debug: bool, version: bool) -> None:
     """Safe Python code modification and refactoring."""
     if version:
-        from python.bowler import __version__
+        from bowler import __version__
 
         click.echo(f"bowler {__version__}")
         return

--- a/bowler/tool.py
+++ b/bowler/tool.py
@@ -136,9 +136,10 @@ class BowlerTool(RefactoringTool):
             return hunks
 
         try:
+            if not input.endswith("\n"):
+                input += "\n"
             tree = self.refactor_string(input, filename)
             hunks = self.processed_file(str(tree), filename, input)
-
         except ParseError:
             self.log_debug("Failed to parse %s, skipping", filename)
 

--- a/docs/basics-setup.md
+++ b/docs/basics-setup.md
@@ -18,7 +18,7 @@ You can also install a development version from source by checking out the Git r
 
 ```bash
 git clone https://github.com/facebookincubator/Bowler
-cd bowler
+cd Bowler
 python setup.py install
 ```
 


### PR DESCRIPTION
**Primarily close #16**. Using print statements for debugging I narrowed the difference in logical flow for files with & without a newline terminator to ``refactor_string()`` imported from ``fissix``, where a ``NoneType`` 'tree' passes silently.

**Additionally**:

* The ``--version`` option did not work for me. This seems to fix it.
* There's a typo in the docs under 'Setup -> Installing Bowler'
*  ~~As cloned, I was unable to set-up the virtual env because of the use of ``source`` in the makefile. ``.`` instead worked & is standardised so perhaps consider changing to this? I'm happy to revert this aspect of the PR, though.~~