### PR TITLE
Applies hunks in single patch call

### DIFF
--- a/bowler/tests/__init__.py
+++ b/bowler/tests/__init__.py
@@ -7,3 +7,4 @@
 
 from .query import QueryTest
 from .smoke import SmokeTest
+from .tool import ToolTest

--- a/bowler/tests/tool.py
+++ b/bowler/tests/tool.py
@@ -118,7 +118,6 @@ class ToolTest(TestCase):
     @mock.patch("bowler.tool.prompt_user")
     @mock.patch("bowler.tool.sh.patch")
     def test_process_hunks_after_auto_yes(self, mock_patch, mock_prompt):
-        self.maxDiff = None
         tool = BowlerTool(Query().compile(), silent=False)
         mock_prompt.side_effect = ["a"]
         tool.process_hunks(target, hunks)
@@ -129,7 +128,6 @@ class ToolTest(TestCase):
     @mock.patch("bowler.tool.prompt_user")
     @mock.patch("bowler.tool.sh.patch")
     def test_process_hunks_after_no_then_yes(self, mock_patch, mock_prompt):
-        self.maxDiff = None
         tool = BowlerTool(Query().compile(), silent=False)
         mock_prompt.side_effect = ["n", "y"]
         tool.process_hunks(target, hunks)
@@ -140,7 +138,6 @@ class ToolTest(TestCase):
     @mock.patch("bowler.tool.prompt_user")
     @mock.patch("bowler.tool.sh.patch")
     def test_process_hunks_after_only_no(self, mock_patch, mock_prompt):
-        self.maxDiff = None
         tool = BowlerTool(Query().compile(), silent=False)
         mock_prompt.side_effect = ["n", "n"]
         tool.process_hunks(target, hunks)

--- a/bowler/tests/tool.py
+++ b/bowler/tests/tool.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import os
+from pathlib import Path
+from unittest import TestCase, mock
+
+from ..tool import BowlerTool, log
+from ..query import Query
+
+
+class ToolTest(TestCase):
+
+    target = Path(__file__).parent / "smoke-target.py"
+
+    def setUp(self):
+        # If the target file has been patched, undo it
+        self.orig_file = Path(__file__).parent / "smoke-target.py.orig"
+        self.rej_file = Path(__file__).parent / "smoke-target.py.rej"
+        if os.path.isfile(self.orig_file):
+            os.rename(self.orig_file, self.target)
+        if os.path.isfile(self.rej_file):
+            os.remove(self.rej_file)
+
+    @mock.patch("bowler.tool.sh.patch")
+    def test_process_hunks_patch_called_correctly(self, mock_patch):
+        tool = BowlerTool(Query().compile(), write=True, interactive=False, silent=True)
+        hunks = [
+            [
+                "--- {self.target}",
+                "+++ {self.target}",
+                "@@ -7,8 +7,8 @@",
+                " ",
+                " ",
+                " # todo: i18n",
+                '-print("Hello world!")',
+                '+print(tr("Hello world!"))',
+                " ",
+                " ",
+                "-def foo():",
+                '+def foo(bar="something"):',
+                "     pass",
+            ],
+            [
+                "--- {self.target}",
+                "+++ {self.target}",
+                "@@ -10,11 +10,11 @@",
+                " ",
+                " ",
+                " # todo: i18n",
+                '-print("Hello world!")',
+                '+print(tr("Hello world!"))',
+                " ",
+                " ",
+                "-def foo():",
+                '+def foo(bar="something"):',
+                "     pass",
+            ],
+        ]
+        tool.process_hunks(self.target, hunks)
+        string_hunks = ""
+        for hunk in hunks:
+            string_hunks += "\n".join(hunk[2:]) + "\n"
+        string_hunks = f"--- {self.target}\n+++ {self.target}\n" + string_hunks
+        mock_patch.assert_called_with(
+            "-u", self.target, _in=string_hunks.encode("utf-8")
+        )
+
+    @mock.patch.object(log, "exception")
+    def test_process_hunks_invalid_hunks(self, mock_log):
+        tool = BowlerTool(Query().compile(), write=True, interactive=False, silent=True)
+        hunks = [
+            [
+                "--- {self.target}",
+                "+++ {self.target}",
+                "@@ -7,8 +7,8 @@",
+                " ",
+                " ",
+                " # todo: i18n",
+                '-print("Hello world!")',
+                '+print(tr("Hello world!"))',
+                " ",
+                " ",
+                "-def foo():",
+                '+def foo(bar="something"):',
+                "     pass",
+            ],
+            [
+                "--- {self.target}",
+                "+++ {self.target}",
+                "@@ -10,11 +10,11 @@",
+                " ",
+                " ",
+                " # todo: i18n",
+                '-print("Hello world!")',
+                '+print(tr("Hello world!"))',
+                " ",
+                " ",
+                "-def foo():",
+                '+def foo(bar="something"):',
+                "     pass",
+            ],
+        ]
+        tool.process_hunks(self.target, hunks)
+        mock_log.assert_called_with(
+            f"hunks failed to apply, rejects saved to {self.target}.rej"
+        )
+        self.assertTrue(os.path.isfile(self.rej_file))
+        self.assertTrue(os.path.isfile(self.orig_file))
+
+    @mock.patch.object(log, "exception")
+    def test_process_hunks_no_hunks(self, mock_log):
+        tool = BowlerTool(Query().compile(), write=True, interactive=False)
+        empty_hunks = [[]]
+        out = tool.process_hunks(self.target, empty_hunks)
+        patch_stderr = "/usr/bin/patch: **** Only garbage was found in the patch input."
+        mock_log.assert_called_with(f"failed to apply patch hunk: {patch_stderr}")
+        self.assertIsNone(out)

--- a/bowler/tests/tool.py
+++ b/bowler/tests/tool.py
@@ -5,104 +5,81 @@ from pathlib import Path
 from unittest import TestCase, mock
 
 from ..tool import BowlerTool, log
+from ..types import BowlerQuit
 from ..query import Query
 
 
+target = Path(__file__).parent / "smoke-target.py"
+hunks = [
+    [
+        f"--- {target}",
+        f"+++ {target}",
+        "@@ -7,8 +7,8 @@",
+        " ",
+        " ",
+        " # todo: i18n",
+        '-print("Hello world!")',
+        '+print(tr("Hello world!"))',
+        " ",
+        " ",
+        "-def foo():",
+        '+def foo(bar="something"):',
+        "     pass",
+    ],
+    [
+        f"--- {target}",
+        f"+++ {target}",
+        "@@ -10,11 +10,11 @@",
+        " ",
+        " ",
+        " # todo: i18n",
+        '-print("Hello world!")',
+        '+print(tr("Hello world!"))',
+        " ",
+        " ",
+        "-def foo():",
+        '+def foo(bar="something"):',
+        "     pass",
+    ],
+]
+
+
 class ToolTest(TestCase):
-
-    target = Path(__file__).parent / "smoke-target.py"
-
     def setUp(self):
-        # If the target file has been patched, undo it
         self.orig_file = Path(__file__).parent / "smoke-target.py.orig"
         self.rej_file = Path(__file__).parent / "smoke-target.py.rej"
+        echo_patcher = mock.patch("bowler.tool.click.echo")
+        secho_patcher = mock.patch("bowler.tool.click.secho")
+        self.addCleanup(echo_patcher.stop)
+        self.addCleanup(secho_patcher.stop)
+        self.mock_echo = echo_patcher.start()
+        self.mock_secho = secho_patcher.start()
+        self.addCleanup(self.cleanup_files)
+
+    def cleanup_files(self):
         if os.path.isfile(self.orig_file):
-            os.rename(self.orig_file, self.target)
+            os.rename(self.orig_file, target)
         if os.path.isfile(self.rej_file):
             os.remove(self.rej_file)
 
     @mock.patch("bowler.tool.sh.patch")
     def test_process_hunks_patch_called_correctly(self, mock_patch):
         tool = BowlerTool(Query().compile(), write=True, interactive=False, silent=True)
-        hunks = [
-            [
-                "--- {self.target}",
-                "+++ {self.target}",
-                "@@ -7,8 +7,8 @@",
-                " ",
-                " ",
-                " # todo: i18n",
-                '-print("Hello world!")',
-                '+print(tr("Hello world!"))',
-                " ",
-                " ",
-                "-def foo():",
-                '+def foo(bar="something"):',
-                "     pass",
-            ],
-            [
-                "--- {self.target}",
-                "+++ {self.target}",
-                "@@ -10,11 +10,11 @@",
-                " ",
-                " ",
-                " # todo: i18n",
-                '-print("Hello world!")',
-                '+print(tr("Hello world!"))',
-                " ",
-                " ",
-                "-def foo():",
-                '+def foo(bar="something"):',
-                "     pass",
-            ],
-        ]
-        tool.process_hunks(self.target, hunks)
+
+        tool.process_hunks(target, hunks)
         string_hunks = ""
         for hunk in hunks:
             string_hunks += "\n".join(hunk[2:]) + "\n"
-        string_hunks = f"--- {self.target}\n+++ {self.target}\n" + string_hunks
-        mock_patch.assert_called_with(
-            "-u", self.target, _in=string_hunks.encode("utf-8")
-        )
+        string_hunks = f"--- {target}\n+++ {target}\n" + string_hunks
+        mock_patch.assert_called_with("-u", target, _in=string_hunks.encode("utf-8"))
 
     @mock.patch.object(log, "exception")
     def test_process_hunks_invalid_hunks(self, mock_log):
         tool = BowlerTool(Query().compile(), write=True, interactive=False, silent=True)
-        hunks = [
-            [
-                "--- {self.target}",
-                "+++ {self.target}",
-                "@@ -7,8 +7,8 @@",
-                " ",
-                " ",
-                " # todo: i18n",
-                '-print("Hello world!")',
-                '+print(tr("Hello world!"))',
-                " ",
-                " ",
-                "-def foo():",
-                '+def foo(bar="something"):',
-                "     pass",
-            ],
-            [
-                "--- {self.target}",
-                "+++ {self.target}",
-                "@@ -10,11 +10,11 @@",
-                " ",
-                " ",
-                " # todo: i18n",
-                '-print("Hello world!")',
-                '+print(tr("Hello world!"))',
-                " ",
-                " ",
-                "-def foo():",
-                '+def foo(bar="something"):',
-                "     pass",
-            ],
-        ]
-        tool.process_hunks(self.target, hunks)
+
+        tool.process_hunks(target, hunks)
         mock_log.assert_called_with(
-            f"hunks failed to apply, rejects saved to {self.target}.rej"
+            f"hunks failed to apply, rejects saved to {target}.rej"
         )
         self.assertTrue(os.path.isfile(self.rej_file))
         self.assertTrue(os.path.isfile(self.orig_file))
@@ -111,7 +88,60 @@ class ToolTest(TestCase):
     def test_process_hunks_no_hunks(self, mock_log):
         tool = BowlerTool(Query().compile(), write=True, interactive=False)
         empty_hunks = [[]]
-        out = tool.process_hunks(self.target, empty_hunks)
+        tool.process_hunks(target, empty_hunks)
         patch_stderr = "/usr/bin/patch: **** Only garbage was found in the patch input."
         mock_log.assert_called_with(f"failed to apply patch hunk: {patch_stderr}")
-        self.assertIsNone(out)
+
+    @mock.patch("bowler.tool.prompt_user")
+    @mock.patch("bowler.tool.sh.patch")
+    def test_process_hunks_after_skip_rest(self, mock_patch, mock_prompt):
+        # Test that we apply the hunks that have been 'yessed' and nothing more
+        tool = BowlerTool(Query().compile(), silent=False)
+        mock_prompt.side_effect = ["y", "d"]
+        tool.process_hunks(target, hunks)
+        mock_patch.assert_called_once_with(
+            "-u", target, _in="\n".join(hunks[0]).encode("utf-8") + b"\n"
+        )
+
+    @mock.patch("bowler.tool.prompt_user")
+    @mock.patch("bowler.tool.sh.patch")
+    def test_process_hunks_after_quit(self, mock_patch, mock_prompt):
+        # Test that we apply the hunks that have been 'yessed' and nothing more
+        tool = BowlerTool(Query().compile(), silent=False)
+        mock_prompt.side_effect = ["y", "q"]
+        with self.assertRaises(BowlerQuit):
+            tool.process_hunks(target, hunks)
+        mock_patch.assert_called_once_with(
+            "-u", target, _in="\n".join(hunks[0]).encode("utf-8") + b"\n"
+        )
+
+    @mock.patch("bowler.tool.prompt_user")
+    @mock.patch("bowler.tool.sh.patch")
+    def test_process_hunks_after_auto_yes(self, mock_patch, mock_prompt):
+        self.maxDiff = None
+        tool = BowlerTool(Query().compile(), silent=False)
+        mock_prompt.side_effect = ["a"]
+        tool.process_hunks(target, hunks)
+        joined_hunks = "".join(["\n".join(hunk[2:]) + "\n" for hunk in hunks])
+        encoded_hunks = f"--- {target}\n+++ {target}\n{joined_hunks}".encode("utf-8")
+        mock_patch.assert_called_once_with("-u", target, _in=encoded_hunks)
+
+    @mock.patch("bowler.tool.prompt_user")
+    @mock.patch("bowler.tool.sh.patch")
+    def test_process_hunks_after_no_then_yes(self, mock_patch, mock_prompt):
+        self.maxDiff = None
+        tool = BowlerTool(Query().compile(), silent=False)
+        mock_prompt.side_effect = ["n", "y"]
+        tool.process_hunks(target, hunks)
+        mock_patch.assert_called_once_with(
+            "-u", target, _in="\n".join(hunks[1]).encode("utf-8") + b"\n"
+        )
+
+    @mock.patch("bowler.tool.prompt_user")
+    @mock.patch("bowler.tool.sh.patch")
+    def test_process_hunks_after_only_no(self, mock_patch, mock_prompt):
+        self.maxDiff = None
+        tool = BowlerTool(Query().compile(), silent=False)
+        mock_prompt.side_effect = ["n", "n"]
+        tool.process_hunks(target, hunks)
+        mock_patch.assert_not_called()

--- a/bowler/tool.py
+++ b/bowler/tool.py
@@ -275,9 +275,11 @@ class BowlerTool(RefactoringTool):
                     self.log_debug(f"result = {result}")
 
                     if result == "q":
+                        self.apply_hunks(accepted_hunks, filename)
                         raise BowlerQuit()
                     elif result == "d":
-                        break  # skip all remaining hunks
+                        self.apply_hunks(accepted_hunks, filename)
+                        return  # skip all remaining hunks
                     elif result == "n":
                         continue
                     elif result == "a":
@@ -289,8 +291,11 @@ class BowlerTool(RefactoringTool):
             if result == "y" or self.write:
                 accepted_hunks += "\n".join(hunk[2:]) + "\n"
 
+        self.apply_hunks(accepted_hunks, filename)
+
+    def apply_hunks(self, accepted_hunks, filename):
         if accepted_hunks:
-            accepted_hunks = f"--- {filename}\n+++ {filename}\n" + accepted_hunks
+            accepted_hunks = f"--- {filename}\n+++ {filename}\n{accepted_hunks}"
             args = ["patch", "-u", filename]
             self.log_debug(f"running {args}")
             try:
@@ -305,7 +310,6 @@ class BowlerTool(RefactoringTool):
                         log.exception(f"hunks failed to apply, rejects saved to{err}")
                         return
                 log.exception(f"failed to apply patch hunk: {err}")
-                return
 
     def run(self, paths: Sequence[str]) -> int:
         if not self.errors:

--- a/bowler/tool.py
+++ b/bowler/tool.py
@@ -243,7 +243,7 @@ class BowlerTool(RefactoringTool):
         auto_yes = False
         need_patch = False
         result = ""
-        accepted_hunks = (f"--- {filename}\n+++ {filename}\n").encode("utf-8")
+        accepted_hunks = f"--- {filename}\n+++ {filename}\n"
         for hunk in hunks:
             if self.hunk_processor(filename, hunk) is False:
                 continue
@@ -284,13 +284,15 @@ class BowlerTool(RefactoringTool):
 
             if result == "y" or self.write:
                 need_patch = True
-                accepted_hunks += ("\n".join(hunk[2:]) + "\n").encode("utf-8")
+                accepted_hunks += "\n".join(hunk[2:]) + "\n"
 
         if need_patch:
             args = ["patch", "-u", filename]
             self.log_debug(f"running {args}")
             try:
-                sh.patch("-u", filename, _in=accepted_hunks)  # type: ignore
+                sh.patch(
+                    "-u", filename, _in=accepted_hunks.encode("utf-8")
+                )  # type: ignore
             except sh.ErrorReturnCode:
                 log.exception("failed to apply patch hunk")
                 return  # TODO: better response?


### PR DESCRIPTION
This should solve[ issue 19](https://github.com/facebookincubator/Bowler/issues/19) by adding all the hunks at once. 
I stripped out the name of the file (the --- filename +++ filename) from the top of each hunk, and created one giant bytestring with the hunks all combined. 

`make lint test` passes.