### PR TITLE
Fix copyright headers

### DIFF
--- a/bowler/__init__.py
+++ b/bowler/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the

--- a/bowler/__main__.py
+++ b/bowler/__main__.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import sys
 
 from .main import main

--- a/bowler/helpers.py
+++ b/bowler/helpers.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import logging
 from typing import List, Optional

--- a/bowler/imr.py
+++ b/bowler/imr.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import logging
 from typing import Any, List, Optional

--- a/bowler/main.py
+++ b/bowler/main.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import importlib
 import logging

--- a/bowler/query.py
+++ b/bowler/query.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import inspect
 import logging

--- a/bowler/tests/__init__.py
+++ b/bowler/tests/__init__.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # This source code is licensed under the MIT license found in the

--- a/bowler/tests/query.py
+++ b/bowler/tests/query.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 
 from unittest import TestCase
 

--- a/bowler/tests/smoke-target.py
+++ b/bowler/tests/smoke-target.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 
 # todo: i18n
 print("Hello world!")

--- a/bowler/tests/smoke.py
+++ b/bowler/tests/smoke.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import logging
 

--- a/bowler/tool.py
+++ b/bowler/tool.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import difflib
 import logging

--- a/bowler/types.py
+++ b/bowler/types.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Any, Callable, Dict, List, NewType, Optional, Type, Union
 

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,4 +1,9 @@
-/* your custom css */
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 @media only screen and (min-device-width: 360px) and (max-device-width: 736px) {
 }


### PR DESCRIPTION
Sets all python files to contain both a python3 shebang and the standard Facebook copyright header.