### PR TITLE
Apply isort with appropriate arguments before running black

### DIFF
--- a/bowler/tests/smoke.py
+++ b/bowler/tests/smoke.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 
 import logging
-
 from pathlib import Path
 from unittest import TestCase
 
 from fissix.fixer_util import Call, Name
-from ..types import TOKEN
+
 from ..query import Query
+from ..types import TOKEN
 
 
 class SmokeTest(TestCase):

--- a/makefile
+++ b/makefile
@@ -14,8 +14,9 @@ release: lint test clean
 	python3 -m twine upload dist/*
 
 format:
+	isort --recursive --multi-line=3 --trailing-comma --force-grid-wrap=0 \
+	  --combine-as --line-width=88 -y bowler setup.py
 	black bowler setup.py
-	isort
 
 lint:
 	black --check bowler setup.py

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 with open("README.md") as f:
     readme = f.read()


### PR DESCRIPTION
Fixes make format to run isort first (with proper arguments and auto-application), and then run black afterwards for final cleanup.