### PR TITLE
Validate AST of transformed files

### DIFF
--- a/bowler/__init__.py
+++ b/bowler/__init__.py
@@ -11,26 +11,26 @@ __author__ = "John Reese, Facebook"
 __version__ = "0.6.0"
 
 from .imr import FunctionArgument, FunctionSpec
+from .query import Query
 from .tool import BowlerTool
 from .types import (
-    BowlerException,
-    IMRError,
-    TOKEN,
-    SYMBOL,
-    START,
-    DROP,
-    STARS,
+    ARG_ELEMS,
     ARG_END,
     ARG_LISTS,
-    ARG_ELEMS,
+    DROP,
     LN,
-    Stringish,
-    Filename,
-    Capture,
+    STARS,
+    START,
+    SYMBOL,
+    TOKEN,
+    BowlerException,
     Callback,
+    Capture,
+    Filename,
     Filter,
     Fixers,
     Hunk,
+    IMRError,
     Processor,
+    Stringish,
 )
-from .query import Query

--- a/bowler/imr.py
+++ b/bowler/imr.py
@@ -8,8 +8,9 @@
 import logging
 from typing import Any, List, Optional
 
-from attr import dataclass
 from fissix.fixer_util import LParen, Name
+
+from attr import dataclass
 
 from .helpers import find_last
 from .types import (

--- a/bowler/main.py
+++ b/bowler/main.py
@@ -33,7 +33,20 @@ def main(ctx: click.Context, debug: bool, version: bool) -> None:
     if debug:
         BowlerTool.NUM_PROCESSES = 1
         BowlerTool.IN_PROCESS = True
-    logging.basicConfig(level=(logging.DEBUG if debug else logging.WARNING))
+
+    root = logging.getLogger()
+    if not root.hasHandlers():
+        logging.addLevelName(logging.DEBUG, "DBG")
+        logging.addLevelName(logging.INFO, "INF")
+        logging.addLevelName(logging.WARNING, "WRN")
+        logging.addLevelName(logging.ERROR, "ERR")
+        level = logging.DEBUG if debug else logging.WARNING
+        fmt = logging.Formatter("{levelname}:{filename}:{lineno}  {message}", style="{")
+        han = logging.StreamHandler(stream=sys.stderr)
+        han.setFormatter(fmt)
+        han.setLevel(level)
+        root.setLevel(level)
+        root.addHandler(han)
 
     if ctx.invoked_subcommand is None:
         return do(None, None)

--- a/bowler/query.py
+++ b/bowler/query.py
@@ -96,6 +96,7 @@ class Query:
         self.processors: List[Processor] = []
         self.retcode: Optional[int] = None
         self.filename_matcher = filename_matcher
+        self.exceptions: List[BowlerException] = []
 
         for path in paths:
             if isinstance(path, str):

--- a/bowler/query.py
+++ b/bowler/query.py
@@ -12,10 +12,11 @@ import re
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, cast
 
-from attr import Factory, dataclass
 from fissix.fixer_base import BaseFix
 from fissix.fixer_util import Attr, Comma, Dot, LParen, Name, Newline, RParen
 from fissix.pytree import Leaf, Node, type_repr
+
+from attr import Factory, dataclass
 
 from .helpers import (
     Once,
@@ -963,7 +964,9 @@ class Query:
             kwargs["hunk_processor"] = processor
 
         kwargs.setdefault("filename_matcher", self.filename_matcher)
-        self.retcode = BowlerTool(fixers, **kwargs).run(self.paths)
+        tool = BowlerTool(fixers, **kwargs)
+        self.retcode = tool.run(self.paths)
+        self.exceptions = tool.exceptions
         return self
 
     def dump(self, selector_pattern=False) -> "Query":

--- a/bowler/tests/__init__.py
+++ b/bowler/tests/__init__.py
@@ -10,4 +10,4 @@ from .lib import BowlerTestCaseTest
 from .query import QueryTest
 from .smoke import SmokeTest
 from .tool import ToolTest
-from .type_inference import OpMinTypeTest, ExpressionTest
+from .type_inference import ExpressionTest, OpMinTypeTest

--- a/bowler/tool.py
+++ b/bowler/tool.py
@@ -258,13 +258,13 @@ class BowlerTool(RefactoringTool):
                 filename, hunks, exc = self.results.get_nowait()
                 results_count += 1
 
-                if isinstance(exc, BowlerException):
+                if exc:
                     self.log_error(f"{type(exc).__name__}: {exc}")
                     if exc.__cause__:
                         self.log_error(
                             f"  {type(exc.__cause__).__name__}: {exc.__cause__}"
                         )
-                    if exc.hunks:
+                    if isinstance(exc, BowlerException) and exc.hunks:
                         diff = "\n".join("\n".join(hunk) for hunk in exc.hunks)
                         self.log_error(f"Generated transform:\n{diff}")
                     self.exceptions.append(exc)

--- a/bowler/types.py
+++ b/bowler/types.py
@@ -7,11 +7,12 @@
 
 from typing import Any, Callable, Dict, List, NewType, Optional, Type, Union
 
-from attr import Factory, dataclass
 from fissix.fixer_base import BaseFix
 from fissix.pgen2 import token
 from fissix.pygram import python_symbols
 from fissix.pytree import Leaf, Node
+
+from attr import Factory, dataclass
 
 
 class Passthrough:
@@ -61,7 +62,12 @@ class Transform:
 
 
 class BowlerException(Exception):
-    pass
+    def __init__(
+        self, message: str = "", *, filename: str = "", hunks: List[Hunk] = None
+    ) -> None:
+        super().__init__(message)
+        self.filename = filename
+        self.hunks = hunks
 
 
 class BowlerQuit(BowlerException):
@@ -73,4 +79,8 @@ class IMRError(BowlerException):
 
 
 class RetryFile(BowlerException):
+    pass
+
+
+class BadTransform(BowlerException):
     pass


### PR DESCRIPTION
After running all transforms on a file, this validates that the
resulting file can be parsed by the AST module.  For files with bad
syntax or other errors, generate a useful error message on stderr, and
skip processing those hunks.  Also tracks the exceptions generated, and
builds a list of all exceptions on the Query object, so they can be
tracked and/or inspected after the query is executed.