### PR TITLE
If IPython is unavailable, default to regular interpreter.

### DIFF
--- a/bowler/main.py
+++ b/bowler/main.py
@@ -52,19 +52,18 @@ def dump(paths: List[str]) -> None:
 def do(interactive: bool, query: str, paths: List[str]) -> None:
     """Execute a query or enter interactive mode."""
     if not query or query == "-":
+
+        namespace = {"Query": Query, "START": START, "SYMBOL": SYMBOL, "TOKEN": TOKEN}
+
         try:
             import IPython
 
-            namespace = {
-                "Query": Query,
-                "START": START,
-                "SYMBOL": SYMBOL,
-                "TOKEN": TOKEN,
-            }
             IPython.start_ipython(argv=[], user_ns=namespace)
 
         except ImportError:
-            pass
+            import code as _code
+
+            _code.interact(local=namespace)
 
         finally:
             return


### PR DESCRIPTION
```
(.venv) darwin ~/src/Bowler git:ipython-fix ✓ $ bowler do
Python 3.7.0 (v3.7.0:1bf9cc5093, Jun 26 2018, 23:26:24)
[Clang 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> Query
<class 'bowler.query.Query'>
>>> ^D
now exiting InteractiveConsole...
(.venv) darwin ~/src/Bowler git:ipython-fix ✓ $ pip install ipython -q
(.venv) darwin ~/src/Bowler git:ipython-fix ✓ $ bowler do
Python 3.7.0 (v3.7.0:1bf9cc5093, Jun 26 2018, 23:26:24)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.1.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: Query
Out[1]: bowler.query.Query
```

tests appear to pass
```
(.venv) darwin ~/src/Bowler git:ipython-fix ✓ $ make lint test
black --check bowler setup.py
All done! ✨ 🍰 ✨
14 files would be left unchanged.
mypy --ignore-missing-imports --python-version 3.6 .
python3 -m unittest -v bowler.tests
test_basic (bowler.tests.query.QueryTest) ... ok
test_tr (bowler.tests.smoke.SmokeTest) ... ok
test_process_hunks_after_auto_yes (bowler.tests.tool.ToolTest) ... ok
test_process_hunks_after_no_then_yes (bowler.tests.tool.ToolTest) ... ok
test_process_hunks_after_only_no (bowler.tests.tool.ToolTest) ... ok
test_process_hunks_after_quit (bowler.tests.tool.ToolTest) ... ok
test_process_hunks_after_skip_rest (bowler.tests.tool.ToolTest) ... ok
test_process_hunks_invalid_hunks (bowler.tests.tool.ToolTest) ... ok
test_process_hunks_no_hunks (bowler.tests.tool.ToolTest) ... ok
test_process_hunks_patch_called_correctly (bowler.tests.tool.ToolTest) ... ok

----------------------------------------------------------------------
Ran 10 tests in 0.152s

OK
```