### PR TITLE
Allow passing a function to match arbitrary filenames

### DIFF
--- a/bowler/helpers.py
+++ b/bowler/helpers.py
@@ -169,3 +169,13 @@ class Once:
         else:
             self.done = True
             return True
+
+
+def filename_endswith(ext):
+    if isinstance(ext, str):
+        ext = [ext]
+
+    def inner(filename):
+        return any(filename.endswith(e) for e in ext)
+
+    return inner

--- a/bowler/query.py
+++ b/bowler/query.py
@@ -82,11 +82,16 @@ def selector(pattern: str) -> Callable[[QM], QM]:
 
 
 class Query:
-    def __init__(self, *paths: Union[str, List[str]]) -> None:
+    def __init__(
+        self,
+        *paths: Union[str, List[str]],
+        filename_matcher: Callable[[str], bool] = None,
+    ) -> None:
         self.paths: List[str] = []
         self.transforms: List[Transform] = []
         self.processors: List[Processor] = []
         self.retcode: Optional[int] = None
+        self.filename_matcher = filename_matcher
 
         for path in paths:
             if isinstance(path, str):
@@ -936,6 +941,8 @@ class Query:
                 return apply
 
             kwargs["hunk_processor"] = processor
+
+        kwargs.setdefault("filename_matcher", self.filename_matcher)
         self.retcode = BowlerTool(fixers, **kwargs).run(self.paths)
         return self
 

--- a/bowler/tool.py
+++ b/bowler/tool.py
@@ -11,7 +11,7 @@ import multiprocessing
 import os
 import time
 from queue import Empty
-from typing import Iterator, List, Sequence, Tuple
+from typing import Callable, Iterator, List, Sequence, Tuple
 
 import click
 import sh
@@ -85,6 +85,7 @@ class BowlerTool(RefactoringTool):
         write: bool = False,
         silent: bool = False,
         hunk_processor: Processor = None,
+        filename_matcher: Callable[[str], bool] = None,
         **kwargs,
     ) -> None:
         options = kwargs.pop("options", {})
@@ -101,6 +102,10 @@ class BowlerTool(RefactoringTool):
             self.hunk_processor = hunk_processor
         else:
             self.hunk_processor = lambda f, h: True
+        if filename_matcher is not None:
+            self.filename_matcher = filename_matcher
+        else:
+            self.filename_matcher = lambda fn: fn.endswith(".py")
 
     def get_fixers(self) -> Tuple[Fixers, Fixers]:
         fixers = [f(self.options, self.fixer_log) for f in self.fixers]
@@ -153,17 +158,17 @@ class BowlerTool(RefactoringTool):
     def refactor_dir(self, dir_name: str, *a, **k) -> None:
         """Descends down a directory and refactor every Python file found.
 
-        Python files are assumed to have a .py extension.
+        Python files are those for which `self.filename_matcher(filename)`
+        returns true, to allow for custom extensions.
 
         Files and subdirectories starting with '.' are skipped.
         """
-        py_ext = os.extsep + "py"
         for dirpath, dirnames, filenames in os.walk(dir_name):
             self.log_debug("Descending into %s", dirpath)
             dirnames.sort()
             filenames.sort()
             for name in filenames:
-                if not name.startswith(".") and os.path.splitext(name)[1] == py_ext:
+                if not name.startswith(".") and self.filename_matcher(name):
                     fullname = os.path.join(dirpath, name)
                     self.queue_work(Filename(fullname))
             # Modify dirnames in-place to remove subdirs with leading dots

--- a/docs/api-query.md
+++ b/docs/api-query.md
@@ -45,12 +45,17 @@ clarity and brevity.
 Create a new query object to process the given set of files or directories.
 
 ```python
-Query(*paths: Union[str, List[str]])
+Query(*paths: Union[str, List[str]], filename_matcher: Callable[[str], bool])
 ```
 
 * `*paths` - Accepts either individual file or directory paths (relative to the current
   working directory), or lists of paths, for any positional argument given.
   Defaults to the current working directory if no arguments given.
+
+* `*filename_matcher*` - A callback which returns whether a given filename is
+  eligible for refactoring.  Defaults to only matching files that end with
+  `.py`.
+
 
 ### `.select()`
 


### PR DESCRIPTION
Haven't run mypy or isort -- see #36

```
from bowler import Query
from bowler.helprts import filename_endswith

Query(["."], filename_matcher=filename_endswith([".pyx", ".foo"]))
```

Note that this does not check filenames given explicitly in args -- they're still processed regardless.