### PR TITLE
Add --match to dump, which shows the form used for matching patterns.

### DIFF
--- a/bowler/helpers.py
+++ b/bowler/helpers.py
@@ -16,6 +16,21 @@ from .types import LN, SYMBOL, Capture, Filename
 log = logging.getLogger(__name__)
 
 
+def print_match(node: LN, results: Capture = None, filename: Filename = None):
+    if isinstance(node, Leaf):
+        click.echo(repr(node.value) + " ", nl=False)
+    else:
+        click.echo(f"{type_repr(node.type)} ", nl=False)
+        if node.children:
+            click.echo("< ", nl=False)
+            for child in node.children:
+                print_match(child)
+            click.echo("> ", nl=False)
+
+    if results:
+        click.echo()
+
+
 def print_tree(
     node: LN,
     results: Capture = None,

--- a/bowler/main.py
+++ b/bowler/main.py
@@ -39,10 +39,11 @@ def main(ctx: click.Context, debug: bool, version: bool) -> None:
 
 
 @main.command()
+@click.option("--match", is_flag=True)
 @click.argument("paths", type=click.Path(exists=True), nargs=-1, required=False)
-def dump(paths: List[str]) -> None:
+def dump(match: bool, paths: List[str]) -> None:
     """Dump the CST representation of each file in <paths>."""
-    return Query(paths).select_root().dump().retcode
+    return Query(paths).select_root().dump(match).retcode
 
 
 @main.command()

--- a/bowler/query.py
+++ b/bowler/query.py
@@ -25,6 +25,7 @@ from .helpers import (
     find_previous,
     get_class,
     power_parts,
+    print_match,
     print_tree,
     quoted_parts,
 )
@@ -939,9 +940,13 @@ class Query:
         self.retcode = BowlerTool(fixers, **kwargs).run(self.paths)
         return self
 
-    def dump(self) -> "Query":
-        for transform in self.transforms:
-            transform.callbacks.append(print_tree)
+    def dump(self, match_form=False) -> "Query":
+        if not match_form:
+            for transform in self.transforms:
+                transform.callbacks.append(print_tree)
+        else:
+            for transform in self.transforms:
+                transform.callbacks.append(print_match)
         return self.execute(write=False)
 
     def diff(self, interactive: bool = False, **kwargs) -> "Query":


### PR DESCRIPTION
This doesn't have a test, but regular dump doesn't either.  This is intended for extremely short snippets, like `def x(n): pass` or `x/2` to then replace some pieces with `any` or `any+`.  Are there cases I'm missing that this won't work?