### PR TITLE
Enable debugging while using bowler

### DIFF
--- a/bowler/main.py
+++ b/bowler/main.py
@@ -32,6 +32,7 @@ def main(ctx: click.Context, debug: bool, version: bool) -> None:
 
     if debug:
         BowlerTool.NUM_PROCESSES = 1
+        BowlerTool.IN_PROCESS = True
     logging.basicConfig(level=(logging.DEBUG if debug else logging.WARNING))
 
     if ctx.invoked_subcommand is None:

--- a/bowler/tool.py
+++ b/bowler/tool.py
@@ -78,6 +78,7 @@ def prompt_user(question: str, options: str, default: str = "") -> str:
 
 class BowlerTool(RefactoringTool):
     NUM_PROCESSES = os.cpu_count() or 1
+    IN_PROCESS = False  # set when run DEBUG mode from command line
 
     def __init__(
         self,
@@ -101,7 +102,8 @@ class BowlerTool(RefactoringTool):
         self.interactive = interactive
         self.write = write
         self.silent = silent
-        self.in_process = in_process
+        # pick the most restrictive of flags
+        self.in_process = in_process or self.IN_PROCESS
         if hunk_processor is not None:
             self.hunk_processor = hunk_processor
         else:


### PR DESCRIPTION
Bowler allows clients to provide their own filters and modifier functions.  During development of these functions, it is helpful to use pdb/ipdb to step into these functions inspect the nodes/capture variables and accordingly write up rules.

Since, bowler by default uses in_process=False, using debug statements in these functions ends up in exiting the program (since the program is confused about stdout/stderrs.) 

By, setting the IN_PROCESS attribute in debug mode, the clients can use pdb/ipdb statements while developing with `bowler`.