### PR TITLE
fix renaming of modules, when nesting of import paths changes

### DIFF
--- a/bowler/query.py
+++ b/bowler/query.py
@@ -651,9 +651,11 @@ class Query:
                         break
                 elif isinstance(value, Node):
                     if type_repr(value.type) == "dotted_name":
+                        dp_old = dotted_parts(old_name)
+                        dp_new = dotted_parts(new_name)
                         parts = zip(
-                            dotted_parts(old_name),
-                            dotted_parts(new_name),
+                            dp_old,
+                            dp_new,
                             value.children,
                         )
                         for old, new, leaf in parts:
@@ -661,6 +663,16 @@ class Query:
                                 break
                             if old != new:
                                 leaf.replace(Name(new, prefix=leaf.prefix))
+
+                        if len(dp_new) < len(dp_old):
+                            # if new path is shorter, remove excess children
+                            value.children = value.children[:len(dp_new)]
+                        elif len(dp_new) > len(dp_old):
+                            # if new path is longer, add new children
+                            for new in dp_new[len(dp_old):]:
+                                value.children.append(Name(new))
+
+
                     elif type_repr(value.type) == "power":
                         pows = zip(dotted_parts(old_name), dotted_parts(new_name))
                         it = iter(value.children)

--- a/bowler/query.py
+++ b/bowler/query.py
@@ -653,11 +653,7 @@ class Query:
                     if type_repr(value.type) == "dotted_name":
                         dp_old = dotted_parts(old_name)
                         dp_new = dotted_parts(new_name)
-                        parts = zip(
-                            dp_old,
-                            dp_new,
-                            value.children,
-                        )
+                        parts = zip(dp_old, dp_new, value.children)
                         for old, new, leaf in parts:
                             if old != leaf.value:
                                 break
@@ -666,12 +662,11 @@ class Query:
 
                         if len(dp_new) < len(dp_old):
                             # if new path is shorter, remove excess children
-                            value.children = value.children[:len(dp_new)]
+                            value.children = value.children[: len(dp_new)]
                         elif len(dp_new) > len(dp_old):
                             # if new path is longer, add new children
-                            for new in dp_new[len(dp_old):]:
+                            for new in dp_new[len(dp_old) :]:
                                 value.children.append(Name(new))
-
 
                     elif type_repr(value.type) == "power":
                         pows = zip(dotted_parts(old_name), dotted_parts(new_name))

--- a/bowler/query.py
+++ b/bowler/query.py
@@ -662,11 +662,11 @@ class Query:
 
                         if len(dp_new) < len(dp_old):
                             # if new path is shorter, remove excess children
-                            value.children = value.children[: len(dp_new)]
+                            del value.children[len(dp_new):len(dp_old)]
                         elif len(dp_new) > len(dp_old):
                             # if new path is longer, add new children
-                            for new in dp_new[len(dp_old) :]:
-                                value.children.append(Name(new))
+                            children = [ Name(new) for new in dp_new[len(dp_old) : len(dp_new)] ]
+                            value.children[len(dp_old):len(dp_old)] = children
 
                     elif type_repr(value.type) == "power":
                         pows = zip(dotted_parts(old_name), dotted_parts(new_name))

--- a/bowler/query.py
+++ b/bowler/query.py
@@ -662,11 +662,13 @@ class Query:
 
                         if len(dp_new) < len(dp_old):
                             # if new path is shorter, remove excess children
-                            del value.children[len(dp_new):len(dp_old)]
+                            del value.children[len(dp_new) : len(dp_old)]
                         elif len(dp_new) > len(dp_old):
                             # if new path is longer, add new children
-                            children = [ Name(new) for new in dp_new[len(dp_old) : len(dp_new)] ]
-                            value.children[len(dp_old):len(dp_old)] = children
+                            children = [
+                                Name(new) for new in dp_new[len(dp_old) : len(dp_new)]
+                            ]
+                            value.children[len(dp_old) : len(dp_old)] = children
 
                     elif type_repr(value.type) == "power":
                         pows = zip(dotted_parts(old_name), dotted_parts(new_name))

--- a/bowler/tests/query.py
+++ b/bowler/tests/query.py
@@ -74,6 +74,23 @@ class FooBar(Foo):
     pass"""
         self.assertMultiLineEqual(expected, output)
 
+    def test_rename_module(self):
+        input = """\
+from a.b.c import D"""
+
+        def selector(arg):
+            return Query(arg).select_module("a.b.c")
+
+        def modifier(q):
+            return q.rename("a.e")
+
+        output = self.run_bowler_modifier(
+            input, selector_func=selector, modifier_func=modifier
+        )
+        expected = """\
+from a.e import D"""
+        self.assertMultiLineEqual(expected, output)
+
     def test_rename_subclass(self):
         input = """\
 class Bar(Foo):

--- a/bowler/tests/query.py
+++ b/bowler/tests/query.py
@@ -76,19 +76,19 @@ class FooBar(Foo):
 
     def test_rename_module(self):
         input = """\
-from a.b.c import D"""
+from a.b.c.d import E"""
 
         def selector(arg):
             return Query(arg).select_module("a.b.c")
 
         def modifier(q):
-            return q.rename("a.e")
+            return q.rename("a.f")
 
         output = self.run_bowler_modifier(
             input, selector_func=selector, modifier_func=modifier
         )
         expected = """\
-from a.e import D"""
+from a.f.d import E"""
         self.assertMultiLineEqual(expected, output)
 
     def test_rename_subclass(self):


### PR DESCRIPTION
this is an attempt at fixing #46 

I'm new to AST and my understanding of how bowler works is quite limited, so this PR might not be the "right solution" - still, it has fixed the problem in the cases that mattered to me.
Happy to improve following your suggestions.