### PR TITLE
Handle renaming modules to names of different lengths.

### DIFF
--- a/bowler/__init__.py
+++ b/bowler/__init__.py
@@ -11,26 +11,26 @@ __author__ = "John Reese, Facebook"
 __version__ = "0.6.0"
 
 from .imr import FunctionArgument, FunctionSpec
+from .query import Query
 from .tool import BowlerTool
 from .types import (
-    BowlerException,
-    IMRError,
-    TOKEN,
-    SYMBOL,
-    START,
-    DROP,
-    STARS,
+    ARG_ELEMS,
     ARG_END,
     ARG_LISTS,
-    ARG_ELEMS,
+    DROP,
     LN,
-    Stringish,
-    Filename,
-    Capture,
+    STARS,
+    START,
+    SYMBOL,
+    TOKEN,
+    BowlerException,
     Callback,
+    Capture,
+    Filename,
     Filter,
     Fixers,
     Hunk,
+    IMRError,
     Processor,
+    Stringish,
 )
-from .query import Query

--- a/bowler/tests/__init__.py
+++ b/bowler/tests/__init__.py
@@ -10,4 +10,4 @@ from .lib import BowlerTestCaseTest
 from .query import QueryTest
 from .smoke import SmokeTest
 from .tool import ToolTest
-from .type_inference import OpMinTypeTest, ExpressionTest
+from .type_inference import ExpressionTest, OpMinTypeTest


### PR DESCRIPTION
Previously Query("foo.py").select_module("a.b").rename("x.y.z") would
change `a.b.func()` to `x.y.func()`. Make sure that rename() handles
`power` properly source and destination having different lengths

Note, this does not fix two issues:
- If someone shadows an import, we can't detect that right now. That requires a stateful visitor, unfortunately.
- There was a kludge added to this method because `module_access` and `module_name` refer to the same underlying node. Without the kludge, we'd end up modifying the same name twice. If there's a better way to handle this, feel free to suggest. I don't think checking if the node is changed is sufficient, because it might be marked changed from modifying a child node. Also, I can't use a set here because Node/Leaf doesn't have a hash. 