### PR TITLE
Switch validation to use fissix instead of ast.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.7.2
+
+* Bug fix: reverify using fissix instead of ast to preserve the ability to modify code
+  that is incompatible with the host version of python (#78)
+
 ## v0.7.1
 
 * Bug fix: skip writing files if they fail to parse after transform (#76)

--- a/bowler/tool.py
+++ b/bowler/tool.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import ast
 import difflib
 import logging
 import multiprocessing
@@ -143,10 +142,12 @@ class BowlerTool(RefactoringTool):
                 hunks.append([a, b, *hunk])
 
             try:
-                ast.parse(new_text, filename)
+                new_tree = self.driver.parse_string(new_text)
+                if new_tree is None:
+                    raise AssertionError("Re-parsed CST is None")
             except Exception as e:
                 raise BadTransform(
-                    f"Transforms generated invalid AST for {filename}",
+                    f"Transforms generated invalid CST for {filename}",
                     filename=filename,
                     hunks=hunks,
                 ) from e


### PR DESCRIPTION
Because ast is from the host python, it rejects all kinds of valid (to some
version of Python) syntax that we might not even have modified in the
transform.  This uses fissix, which I believe is strict enough to catch the
typical errors like mismatched parens, extra commas, or bad indentation.

Fixes #77