### PR TITLE
Log the full traceback in errors

### DIFF
--- a/bowler/tool.py
+++ b/bowler/tool.py
@@ -213,10 +213,10 @@ class BowlerTool(RefactoringTool):
                 self.log_debug(f"Retrying {filename} later...")
                 self.queue.put(filename)
             except BowlerException as e:
-                log.error(f"Bowler exception during transform of {filename}: {e}")
+                log.exception(f"Bowler exception during transform of {filename}: {e}")
                 self.results.put((filename, e.hunks, e))
             except Exception as e:
-                log.error(f"Skipping {filename}: failed to transform because {e}")
+                log.exception(f"Skipping {filename}: failed to transform because {e}")
                 self.results.put((filename, [], e))
 
             finally:


### PR DESCRIPTION
Previously, Bowler's error logging was not partiuclarly helpful, e.g.:

```
ERR:tool.py:216  Skipping t.py: failed to transform because
ERR:tool.py:118  AssertionError:
```

With this patch, it includes the full traceback:

```
ERR:tool.py:219  Skipping t.py: failed to transform because
Traceback (most recent call last):
  File "/Users/andy/forks/Bowler/bowler/tool.py", line 209, in refactor_queue
    hunks = self.refactor_file(filename)
  File "/Users/andy/forks/Bowler/bowler/tool.py", line 171, in refactor_file
    tree = self.refactor_string(input, filename)
  File "/Users/andy/.virtualenvs/tmp-4d43f26bfaec7fd/lib/python3.7/site-packages/fissix/refactor.py", line 370, in refactor_string
    self.refactor_tree(tree, name)
  File "/Users/andy/.virtualenvs/tmp-4d43f26bfaec7fd/lib/python3.7/site-packages/fissix/refactor.py", line 410, in refactor_tree
    self.traverse_by(self.bmi_post_order_heads, tree.post_order())
  File "/Users/andy/.virtualenvs/tmp-4d43f26bfaec7fd/lib/python3.7/site-packages/fissix/refactor.py", line 486, in traverse_by
    new = fixer.transform(node, results)
  File "/Users/andy/forks/Bowler/bowler/query.py", line 967, in transform
    if not filters or all(f(node, capture, filename) for f in filters):
  File "/Users/andy/forks/Bowler/bowler/query.py", line 967, in <genexpr>
    if not filters or all(f(node, capture, filename) for f in filters):
  File "add_markers.py", line 92, in filter_not_already_marked
    assert name.type == SYMBOL.dotted_name
AssertionError
ERR:tool.py:117  AssertionError:
```