### PR TITLE
Don't compare retcode with 'None'

### DIFF
--- a/bowler/main.py
+++ b/bowler/main.py
@@ -87,7 +87,7 @@ def do(interactive: bool, query: str, paths: List[str]) -> None:
     result = eval(code)  # noqa eval() - developer tool, hopefully they're not dumb
 
     if isinstance(result, Query):
-        if result.retcode is not None:
+        if result.retcode:
             exc = click.ClickException("query failed")
             exc.exit_code = result.retcode
             raise exc


### PR DESCRIPTION
Fix #49: Since retcode will always be an integer 0 or 1 this was always bound to fail.

@jreese I checked there weren't any errors while running query, but as you said all instances weren't replaced Can it be because of not matching with the Pattern?

