### PR TITLE
Stop shelling out to patch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - tmp-*
     tags:
       - v*
   pull_request:
@@ -13,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7]
-        os: [macOS-latest, ubuntu-latest]
+        python-version: [3.6, 3.7, 3.8]
+        os: [macOS-latest, ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v1

--- a/bowler/tests/lib.py
+++ b/bowler/tests/lib.py
@@ -14,6 +14,7 @@ from contextlib import contextmanager
 from io import StringIO
 
 import click
+import volatile
 from fissix import pygram, pytree
 from fissix.pgen2.driver import Driver
 
@@ -97,12 +98,12 @@ class BowlerTestCase(unittest.TestCase):
         if query_func is None:
             query_func = default_query_func
 
-        with tempfile.NamedTemporaryFile(suffix=".py") as f:
+        with volatile.file(mode="w", suffix=".py") as f:
             # TODO: I'm almost certain this will not work on Windows, since
             # NamedTemporaryFile has it already open for writing.  Consider
             # using mktemp directly?
-            with open(f.name, "w") as fw:
-                fw.write(input_text + "\n")
+            f.write(input_text + "\n")
+            f.close()
 
             query = query_func([f.name])
             assert query is not None, "Remember to return the Query"

--- a/bowler/tool.py
+++ b/bowler/tool.py
@@ -9,6 +9,7 @@ import difflib
 import logging
 import multiprocessing
 import os
+import sys
 import time
 from queue import Empty
 from typing import Any, Callable, Iterator, List, Optional, Sequence, Tuple
@@ -90,7 +91,7 @@ class BowlerTool(RefactoringTool):
         interactive: bool = True,
         write: bool = False,
         silent: bool = False,
-        in_process: bool = False,
+        in_process: Optional[bool] = None,
         hunk_processor: Processor = None,
         filename_matcher: Optional[FilenameMatcher] = None,
         **kwargs,
@@ -105,8 +106,13 @@ class BowlerTool(RefactoringTool):
         self.interactive = interactive
         self.write = write
         self.silent = silent
-        # pick the most restrictive of flags
-        self.in_process = in_process or self.IN_PROCESS
+        if in_process is None:
+            in_process = self.IN_PROCESS
+        # pick the most restrictive of flags; we can pickle fixers when
+        # using spawn.
+        if sys.platform == "win32" or sys.version_info > (3, 7):
+            in_process = True
+        self.in_process = in_process
         self.exceptions: List[BowlerException] = []
         if hunk_processor is not None:
             self.hunk_processor = hunk_processor

--- a/makefile
+++ b/makefile
@@ -20,13 +20,7 @@ format:
 	black bowler setup.py
 
 lint:
-	@/bin/bash -c 'die() { echo "$$1"; exit 1; }; \
-	  while read filename; do \
-	  grep -q "Copyright (c) Facebook" "$$filename" || \
-	    die "Missing copyright in $$filename"; \
-	  grep -q "#!/usr/bin/env python3" "$$filename" || \
-	    die "Missing #! in $$filename"; \
-	  done < <( git ls-tree -r --name-only HEAD | grep ".py$$" )'
+	/bin/bash scripts/check_copyright.sh
 	black --check bowler setup.py
 	mypy -m bowler
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,4 @@ isort
 mypy
 python-coveralls
 twine
-volatile
 wheel

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,5 @@ isort
 mypy-mypyc
 python-coveralls
 twine
+volatile
 wheel

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ black
 codecov
 coverage
 isort
-mypy-mypyc
+mypy
 python-coveralls
 twine
 volatile

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ attrs
 click
 fissix
 moreorless>=0.2.0
+volatile

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 attrs
 click
 fissix
-sh
+moreorless>=0.2.0

--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+die() { echo "$1"; exit 1; }
+
+while read filename; do
+  grep -q "Copyright (c) Facebook" "$filename" ||
+    die "Missing copyright in $filename";
+  grep -q "#!/usr/bin/env python3" "$filename" ||
+    die "Missing #! in $filename";
+done < <( git ls-tree -r --name-only HEAD | grep ".py$" )


### PR DESCRIPTION
* Switch to using my [`moreorless` library](https://github.com/thatch/moreorless), which is capable of diffing and patching including "No newline at eof" cross-platform.  No longer saves reject files.  I don't know how that would have been possible to begin with if we're only picking and choosing hunks, rather than editing them (or the original sources change out from under us).  Only modifies the file after a successful patch.

* Several build/test related fixes
  * enable tests on windows and 3.8, run on branches that start with "tmp-" too
  * force in_process mode on Windows and more recent Python (this could probably be more nuanced, but this works at the expense of it being single-threaded).  I'm also not 100% sure of the conditions here; can we detect if the multiprocessing start method isn't fork?
  * use mypy instead of mypy-mypyc, because of a version conflict on typed-ast with black
  * use volatile, which is like tempfile but better (particularly on windows)
  * move the script that checks for copyright notices to a file, instead of bash -c (something about the multiline literal doesn't work on windows)

Fixes #8, Fixes #58, Fixes #52 