### PR TITLE
handle py2/py3 print statement vs function better (via user configurable option)

### DIFF
--- a/bowler/query.py
+++ b/bowler/query.py
@@ -10,9 +10,8 @@ import logging
 import pathlib
 import re
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, cast
+from typing import Callable, List, Optional, Type, TypeVar, Union, cast
 
-from attr import Factory, dataclass
 from fissix.fixer_base import BaseFix
 from fissix.fixer_util import Attr, Comma, Dot, LParen, Name, Newline, RParen
 from fissix.pytree import Leaf, Node, type_repr
@@ -88,6 +87,7 @@ class Query:
     def __init__(
         self,
         *paths: Union[str, List[str]],
+        python_version: int = 3,
         filename_matcher: Optional[FilenameMatcher] = None,
     ) -> None:
         self.paths: List[str] = []
@@ -95,6 +95,7 @@ class Query:
         self.processors: List[Processor] = []
         self.retcode: Optional[int] = None
         self.filename_matcher = filename_matcher
+        self.python_version = python_version
         self.exceptions: List[BowlerException] = []
 
         for path in paths:
@@ -995,6 +996,8 @@ class Query:
             kwargs["hunk_processor"] = processor
 
         kwargs.setdefault("filename_matcher", self.filename_matcher)
+        if self.python_version == 3:
+            kwargs.setdefault("options", {})["print_function"] = True
         tool = BowlerTool(fixers, **kwargs)
         self.retcode = tool.run(self.paths)
         self.exceptions = tool.exceptions

--- a/bowler/query.py
+++ b/bowler/query.py
@@ -87,8 +87,8 @@ class Query:
     def __init__(
         self,
         *paths: Union[str, List[str]],
-        python_version: int = 3,
         filename_matcher: Optional[FilenameMatcher] = None,
+        python_version: int = 3,
     ) -> None:
         self.paths: List[str] = []
         self.transforms: List[Transform] = []

--- a/bowler/tests/lib.py
+++ b/bowler/tests/lib.py
@@ -8,9 +8,7 @@
 import functools
 import multiprocessing
 import sys
-import tempfile
 import unittest
-from contextlib import contextmanager
 from io import StringIO
 
 import click

--- a/bowler/tests/query.py
+++ b/bowler/tests/query.py
@@ -51,27 +51,23 @@ class QueryTest(BowlerTestCase):
     def test_parse_print_func_py3(self):
         # Py 3 mode is the default
         def select_print_func(arg):
-            return (
-                Query(arg)
-                .select_var("bar")
-                .rename("baz")
-            )
+            return Query(arg).select_var("bar").rename("baz")
 
         template = """{} = 1; {}"""
         self.run_bowler_modifiers(
             [
                 (
                     # ParseError prevents rename succeeding
-                    template.format("bar", "print \"hello world\""),
-                    template.format("bar", "print \"hello world\"")
+                    template.format("bar", 'print "hello world"'),
+                    template.format("bar", 'print "hello world"'),
                 ),
                 (
-                    template.format("bar", "print(\"hello world\")"),
-                    template.format("baz", "print(\"hello world\")")
+                    template.format("bar", 'print("hello world")'),
+                    template.format("baz", 'print("hello world")'),
                 ),
                 (
-                    template.format("bar", "print(\"hello world\", end=\"\")"),
-                    template.format("baz", "print(\"hello world\", end=\"\")")
+                    template.format("bar", 'print("hello world", end="")'),
+                    template.format("baz", 'print("hello world", end="")'),
                 ),
             ],
             query_func=select_print_func,
@@ -79,28 +75,24 @@ class QueryTest(BowlerTestCase):
 
     def test_parse_print_func_py2(self):
         def select_print_func(arg):
-            return (
-                Query(arg, python_version=2)
-                .select_var("bar")
-                .rename("baz")
-            )
+            return Query(arg, python_version=2).select_var("bar").rename("baz")
 
         template = """{} = 1; {}"""
         self.run_bowler_modifiers(
             [
                 (
-                    template.format("bar", "print \"hello world\""),
-                    template.format("baz", "print \"hello world\"")
+                    template.format("bar", 'print "hello world"'),
+                    template.format("baz", 'print "hello world"'),
                 ),
                 (
                     # not a print function call, just parenthesised statement
-                    template.format("bar", "print(\"hello world\")"),
-                    template.format("baz", "print(\"hello world\")")
+                    template.format("bar", 'print("hello world")'),
+                    template.format("baz", 'print("hello world")'),
                 ),
                 (
                     # ParseError prevents rename succeeding
-                    template.format("bar", "print(\"hello world\", end=\"\")"),
-                    template.format("bar", "print(\"hello world\", end=\"\")")
+                    template.format("bar", 'print("hello world", end="")'),
+                    template.format("bar", 'print("hello world", end="")'),
                 ),
             ],
             query_func=select_print_func,
@@ -108,11 +100,7 @@ class QueryTest(BowlerTestCase):
 
     def test_parse_print_func_py2_future_print(self):
         def select_print_func(arg):
-            return (
-                Query(arg, python_version=2)
-                .select_var("bar")
-                .rename("baz")
-            )
+            return Query(arg, python_version=2).select_var("bar").rename("baz")
 
         template = """\
 from __future__ import print_function
@@ -121,16 +109,16 @@ from __future__ import print_function
             [
                 (
                     # ParseError prevents rename succeeding
-                    template.format("bar", "print \"hello world\""),
-                    template.format("bar", "print \"hello world\"")
+                    template.format("bar", 'print "hello world"'),
+                    template.format("bar", 'print "hello world"'),
                 ),
                 (
-                    template.format("bar", "print(\"hello world\")"),
-                    template.format("baz", "print(\"hello world\")")
+                    template.format("bar", 'print("hello world")'),
+                    template.format("baz", 'print("hello world")'),
                 ),
                 (
-                    template.format("bar", "print(\"hello world\", end=\"\")"),
-                    template.format("baz", "print(\"hello world\", end=\"\")")
+                    template.format("bar", 'print("hello world", end="")'),
+                    template.format("baz", 'print("hello world", end="")'),
                 ),
             ],
             query_func=select_print_func,

--- a/bowler/tool.py
+++ b/bowler/tool.py
@@ -15,7 +15,6 @@ from queue import Empty
 from typing import Any, Iterator, List, Optional, Sequence, Tuple
 
 import click
-import sh
 from fissix import pygram
 from fissix.pgen2.parse import ParseError
 from fissix.refactor import RefactoringTool, _detect_future_features

--- a/bowler/tool.py
+++ b/bowler/tool.py
@@ -147,8 +147,8 @@ class BowlerTool(RefactoringTool):
             if hunk:
                 hunks.append([a, b, *hunk])
 
-            features = _detect_future_features(new_text)
-            if "print_function" in features:
+            original_grammar = self.driver.grammar
+            if "print_function" in _detect_future_features(new_text):
                 self.driver.grammar = pygram.python_grammar_no_print_statement
             try:
                 new_tree = self.driver.parse_string(new_text)
@@ -160,6 +160,8 @@ class BowlerTool(RefactoringTool):
                     filename=filename,
                     hunks=hunks,
                 ) from e
+            finally:
+                self.driver.grammar = original_grammar
 
         return hunks
 

--- a/docs/api-query.md
+++ b/docs/api-query.md
@@ -45,14 +45,23 @@ clarity and brevity.
 Create a new query object to process the given set of files or directories.
 
 ```python
-Query(*paths: Union[str, List[str]], filename_matcher: FilenameMatcher)
+Query(
+  *paths: Union[str, List[str]],
+  python_version: int,
+  filename_matcher: FilenameMatcher,
+)
 ```
 
 * `*paths` - Accepts either individual file or directory paths (relative to the current
   working directory), or lists of paths, for any positional argument given.
   Defaults to the current working directory if no arguments given.
 
-* `*filename_matcher*` - A callback which returns whether a given filename is
+* `python_version` - The 'major' python version of the files to be refactored, i.e. `2`
+  or `3`. This allows the parser to handle `print` statement vs function correctly. This
+  includes detecting use of `from __future__ import print_function` when
+  `python_version=2`. Default is `3`.
+
+* `filename_matcher` - A callback which returns whether a given filename is
   eligible for refactoring.  Defaults to only matching files that end with
   `.py`.
 

--- a/docs/api-query.md
+++ b/docs/api-query.md
@@ -56,14 +56,14 @@ Query(
   working directory), or lists of paths, for any positional argument given.
   Defaults to the current working directory if no arguments given.
 
+* `*filename_matcher*` - A callback which returns whether a given filename is
+  eligible for refactoring.  Defaults to only matching files that end with
+  `.py`.
+
 * `python_version` - The 'major' python version of the files to be refactored, i.e. `2`
   or `3`. This allows the parser to handle `print` statement vs function correctly. This
   includes detecting use of `from __future__ import print_function` when
   `python_version=2`. Default is `3`.
-
-* `filename_matcher` - A callback which returns whether a given filename is
-  eligible for refactoring.  Defaults to only matching files that end with
-  `.py`.
 
 
 ### `.select()`


### PR DESCRIPTION
fixes #119 

this allows Bowler to refactor py2 files containing `print` statements