### PR TITLE
mark bowler package as typed, check all files with mypy

### DIFF
--- a/bowler/main.py
+++ b/bowler/main.py
@@ -11,8 +11,9 @@ import logging
 import os.path
 import sys
 import unittest
+from importlib.abc import Loader
 from pathlib import Path
-from typing import List
+from typing import cast, List
 
 import click
 
@@ -152,7 +153,7 @@ def test(codemod: str) -> None:
     module_name_from_codemod = os.path.basename(codemod).replace(".py", "")
     spec = importlib.util.spec_from_file_location(module_name_from_codemod, codemod)
     foo = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(foo)
+    cast(Loader, spec.loader).exec_module(foo)
     suite = unittest.TestLoader().loadTestsFromModule(foo)
 
     result = unittest.TextTestRunner().run(suite)

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ format:
 lint:
 	/bin/bash scripts/check_copyright.sh
 	black --check bowler setup.py
-	mypy -m bowler
+	mypy -p bowler
 
 test:
 	python -m coverage run -m bowler.tests


### PR DESCRIPTION
For other projects using Bowler it needs to have the `py.typed` marker file to tell mypy, when run by the other project, that Bowler is typed and to use its annotations

I thought I'd just quickly run mypy on it to make sure it's ok to mark it this way, this reported the following error:
```
bowler/main.py:156: error: Item "_Loader" of "Optional[_Loader]" has no attribute "exec_module"
bowler/main.py:156: error: Item "None" of "Optional[_Loader]" has no attribute "exec_module"
```

I fixed this based on the advice here https://github.com/python/typeshed/issues/2793

Then digging around I saw you're already running mypy in the github CI. The problem seems to be that `make lint` currently runs it as `mypy -m bowler`

This reports:
```
Success: no issues found in 1 source file
```

https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-m
> Mypy _will not_ recursively type check any submodules of the provided module.

...so it hasn't checked everything.


Using the `-p` "package" option, with the fix in `main.py`, reports:
```
Success: no issues found in 19 source files
```

This will be running mypy against the modules in the `tests` package though, which you may not want.  At the moment they all pass fine, if you don't want them type-checked then we could add an ignore to setup.cfg like:
```ini
[mypy-bowler.tests.*]
ignore_errors = True
```
...or just move the `tests` package out of the `bowler` package and up to root level.