### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -23,6 +23,10 @@ const users = [
 const repoUrl = 'https://github.com/facebookincubator/bowler';
 
 const siteConfig = {
+  algolia: {
+      apiKey: '54987596d168f804b64977e44742c4b7',
+      indexName: 'facebookincubator_bowler'
+  },
   title: 'Bowler' /* title for your website */,
   tagline: 'Safe code refactoring for modern Python',
   url: 'https://pybowler.io' /* your website url */,


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.