### PR TITLE
Move to declarative metadata, setuptools_scm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# setuptools_scm
+bowler/version.py
+
 # Docusaurus
 .DS_Store
 

--- a/bowler/__init__.py
+++ b/bowler/__init__.py
@@ -8,7 +8,10 @@
 """Safe code refactoring for modern Python projects."""
 
 __author__ = "John Reese, Facebook"
-__version__ = "0.9.0"
+try:
+    from .version import version as __version__
+except ImportError:
+    __version__ = "dev"
 
 from .imr import FunctionArgument, FunctionSpec
 from .query import Query

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ ignore_missing_imports = True
 [metadata]
 name = bowler
 description = Safe code refactoring for modern Python projects
+long_description = file: README.md
 long_description_content_type = text/markdown
 author = John Reese, Facebook
 author_email = jreese@fb.com
@@ -34,6 +35,7 @@ classifiers =
   Programming Language :: Python :: 3
   Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
+  Programming Language :: Python :: 3.8
 license = MIT
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,33 @@ use_parentheses = True
 
 [mypy]
 ignore_missing_imports = True
+
+[metadata]
+name = bowler
+description = Safe code refactoring for modern Python projects
+long_description_content_type = text/markdown
+author = John Reese, Facebook
+author_email = jreese@fb.com
+url = https://github.com/facebookincubator/bowler
+classifiers =
+  Development Status :: 1 - Planning
+  Intended Audience :: Developers
+  License :: OSI Approved :: MIT License
+  Programming Language :: Python
+  Programming Language :: Python :: 3
+  Programming Language :: Python :: 3.6
+  Programming Language :: Python :: 3.7
+license = MIT
+
+[options]
+packages =
+  bowler
+  bowler.tests
+test_suite = bowler.tests
+python_requires = >=3.6
+setup_requires =
+  setuptools>=38.6.0
+
+[options.entry_points]
+console_scripts =
+  bowler = bowler.main:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ packages =
 test_suite = bowler.tests
 python_requires = >=3.6
 setup_requires =
+  setuptools_scm
   setuptools>=38.6.0
 
 [options.entry_points]

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,10 @@
 
 from setuptools import find_packages, setup
 
-with open("bowler/__init__.py") as f:
-    for line in f:
-        if line.startswith("__version__"):
-            version = line.split('"')[1]
-
 with open("requirements.txt") as f:
     requires = f.read().strip().splitlines()
 
 setup(
-    version=version,
     install_requires=requires,
+    use_scm_version={"write_to": "bowler/version.py"},
 )

--- a/setup.py
+++ b/setup.py
@@ -19,28 +19,7 @@ with open("requirements.txt") as f:
     requires = f.read().strip().splitlines()
 
 setup(
-    name="bowler",
-    description="Safe code refactoring for modern Python projects",
     long_description=readme,
-    long_description_content_type="text/markdown",
     version=version,
-    author="John Reese, Facebook",
-    author_email="jreese@fb.com",
-    url="https://github.com/facebookincubator/bowler",
-    classifiers=[
-        "Development Status :: 1 - Planning",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-    ],
-    license="MIT",
-    packages=["bowler", "bowler.tests"],
-    test_suite="bowler.tests",
-    python_requires=">=3.6",
-    setup_requires=["setuptools>=38.6.0"],
     install_requires=requires,
-    entry_points={"console_scripts": ["bowler = bowler.main:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,6 @@
 
 from setuptools import find_packages, setup
 
-with open("README.md") as f:
-    readme = f.read()
-
 with open("bowler/__init__.py") as f:
     for line in f:
         if line.startswith("__version__"):
@@ -19,7 +16,6 @@ with open("requirements.txt") as f:
     requires = f.read().strip().splitlines()
 
 setup(
-    long_description=readme,
     version=version,
     install_requires=requires,
 )


### PR DESCRIPTION
I'm saving `requirements.txt` for another day; I would like to see good minimum versions listed.  These could also move to `pyproject.toml` but I don't currently have that scripted, let me know.