### PR TITLE
Better min versions for deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,3 +35,5 @@ jobs:
     - name: Coverage
       run: codecov --token ${{ secrets.CODECOV_TOKEN }} --branch ${{ github.ref }}
       continue-on-error: true
+    - name: Pessimist
+      run: python -m pessimist --fast .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ python-coveralls==2.9.3
 twine==3.2.0
 wheel==0.35.1
 pessimist==0.7.0
+setuptools>=48.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ mypy==0.782
 python-coveralls==2.9.3
 twine==3.2.0
 wheel==0.35.1
+pessimist==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-attrs
-click
-fissix
+attrs>=17.3.0
+click>=6.0
+fissix>=20.5.1
 moreorless>=0.2.0
 volatile


### PR DESCRIPTION
Enables pessimist on CI so it should be more difficult to get into this state in the future.