### PR TITLE
Mirror logic that appends newline on patch application.

### DIFF
--- a/bowler/tool.py
+++ b/bowler/tool.py
@@ -351,17 +351,19 @@ class BowlerTool(RefactoringTool):
 
     def apply_hunks(self, accepted_hunks, filename):
         if accepted_hunks:
-            with open(filename) as f:
-                data = f.read()
+            input, encoding = self._read_python_source(filename)
+
+            if not input.endswith("\n"):
+                input += "\n"
 
             try:
                 accepted_hunks = f"--- {filename}\n+++ {filename}\n{accepted_hunks}"
-                new_data = apply_single_file(data, accepted_hunks)
+                new_data = apply_single_file(input, accepted_hunks)
             except PatchException as err:
                 log.exception(f"failed to apply patch hunk: {err}")
                 return
 
-            with open(filename, "w") as f:
+            with open(filename, "w", encoding=encoding) as f:
                 f.write(new_data)
 
     def run(self, paths: Sequence[str]) -> int:


### PR DESCRIPTION
The important parts are:

- `refactor_file` adds a newline.  it doesn't take it away, because
- `refactor_file` calls `processed_file` which does an ast re-parse
- `apply_hunks` has at least two bugs; one is the reported one about newlines, but it also appears to not obey cookies.

Ensuring that these 3 paths would always obey cookies and see contents that end with a newline seemed the simpler path.  Includes a test that edits the (last, only, missing newline) line.